### PR TITLE
fix compiler warnings

### DIFF
--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -1,0 +1,38 @@
+name: c++-checks
+
+on:
+  pull_request:
+    branches: main
+  push:
+    branches: main
+
+env:
+  # (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  cc-build-format-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: configure
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .
+
+    - name: build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: format
+      uses: cpp-linter/cpp-linter-action@v2
+      id: linter
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        style: file
+
+    - name: check failure
+      if: steps.linter.outputs.checks-failed > 0
+      run: |
+        echo "Some files failed the linting checks!"
+        #exit 1

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -65,10 +65,10 @@ jobs:
         mv figures ../
         cd ..
     - name: upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: figures
+      uses: actions/upload-artifact@v3
+      with:
+        name: results
+        path: figures
 
 
   # Single deploy job since we're just deploying

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -6,6 +6,21 @@ on:
   push:
     branches: main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 env:
   # (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RelWithDebInfo
@@ -47,10 +62,38 @@ jobs:
         mv *.json results/
         mkdir figures
         python ../test/analyze.py
-        mv figures/*.png ../
-        echo "![](build-k10.png)" >> $GITHUB_STEP_SUMMARY
-        echo "![](total-k10.png)" >> $GITHUB_STEP_SUMMARY
-        echo "![](query-k10.png)" >> $GITHUB_STEP_SUMMARY
+        mv figures ../
+        cd ..
+    - name: upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: results
+          path: figures
+
+
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-lint-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: results
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: 'figures/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 
 
 

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -11,7 +11,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
 
 jobs:
-  cc-build-format-test:
+  build-lint-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,7 +25,7 @@ jobs:
     - name: build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: format
+    - name: lint
       uses: cpp-linter/cpp-linter-action@v2
       id: linter
       env:
@@ -47,6 +47,7 @@ jobs:
         mv *.json results/
         mkdir figures
         python ../test/analyze.py
+        mv *.png ../
         echo "![](figures/build-k10.png)" >> $GITHUB_STEP_SUMMARY
         echo "![](figures/total-k10.png)" >> $GITHUB_STEP_SUMMARY
         echo "![](figures/query-k10.png)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: configure
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .
+        pip install matplotlib
 
     - name: build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
@@ -36,3 +38,20 @@ jobs:
       run: |
         echo "Some files failed the linting checks!"
         #exit 1
+    
+    - name: run benchmarks
+      run: |
+        cd build
+        python ../test/benchmark.py --test lite
+        mkdir results
+        mv *.json results/
+        mkdir figures
+        python ../test/analyze.py
+        echo "![](figures/build-k10.png)" >> $GITHUB_STEP_SUMMARY
+        echo "![](figures/total-k10.png)" >> $GITHUB_STEP_SUMMARY
+        echo "![](figures/query-k10.png)" >> $GITHUB_STEP_SUMMARY
+
+
+
+
+      

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -62,16 +62,14 @@ jobs:
         mv *.json results/
         mkdir figures
         python ../test/analyze.py
-        mv figures ../
+        mv figures ../results
         cd ..
     - name: upload results
       uses: actions/upload-artifact@v3
       with:
         name: results
-        path: figures/*.png
+        path: figures
 
-
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -90,7 +88,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: '*.png'
+          path: './results'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: results
-        path: figures
+        path: figures/*.png
 
 
   # Single deploy job since we're just deploying
@@ -90,7 +90,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: 'figures/'
+          path: '*.png'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -47,10 +47,10 @@ jobs:
         mv *.json results/
         mkdir figures
         python ../test/analyze.py
-        mv *.png ../
-        echo "![](figures/build-k10.png)" >> $GITHUB_STEP_SUMMARY
-        echo "![](figures/total-k10.png)" >> $GITHUB_STEP_SUMMARY
-        echo "![](figures/query-k10.png)" >> $GITHUB_STEP_SUMMARY
+        mv figures/*.png ../
+        echo "![](build-k10.png)" >> $GITHUB_STEP_SUMMARY
+        echo "![](total-k10.png)" >> $GITHUB_STEP_SUMMARY
+        echo "![](query-k10.png)" >> $GITHUB_STEP_SUMMARY
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,28 +1,23 @@
-name: c++-checks
+name: checks
 
 on:
   pull_request:
     branches: main
   push:
     branches: main
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 env:
-  # (Release, Debug, RelWithDebInfo, etc.)
+  # (Release, Debug, RelWithDebInfo)
   BUILD_TYPE: RelWithDebInfo
 
 jobs:
@@ -68,7 +63,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: results
-        path: figures
+        path: results
 
   deploy:
     environment:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: './results'
+          path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-set(CMAKE_CXX_COMPILER g++-13)
+#set(CMAKE_CXX_COMPILER g++-13)
 
 project(mapletrees LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-#set(CMAKE_CXX_COMPILER g++-13)
+set(CMAKE_CXX_COMPILER g++-13)
 
 project(mapletrees LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-O3 -fPIC -ffast-math -funroll-loops -ffp-contract=fast")
+set(CMAKE_CXX_FLAGS "-O3 -fPIC -ffast-math -funroll-loops -ffp-contract=fast -Wall")
 add_definitions(-DNDEBUG)
 #set(CMAKE_CXX_FLAGS "-g -O0 -fsanitize=address")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 #set(CMAKE_CXX_COMPILER g++-13)
 
-project(mapletrees LANGUAGES CXX)
+project(trees LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-O3 -fPIC -ffast-math -funroll-loops -ffp-contract=fast -Wall")

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-### **about**
+### **About**
 
-`mapletrees` is a header-only library for creating trees (currently only kdtrees) that may be useful for polygon meshing, with a focus on simplicity and efficiency for constructing and querying kdtrees (e.g. for k-nearest neighbors).
+This project provides a header-only library for creating trees (currently only kdtrees) that may be useful for polygon meshing, with a focus on simplicity and efficiency for constructing and querying kdtrees (e.g. for k-nearest neighbors).
 
 Currently, two types of trees are offered. The first tree is _balanced_ in that each node should have roughly the same number of nodes in the left and right subtrees. In this implementation, left and right children of a node are referenced by integers into the global array of nodes. The second tree is _left-balanced_ so that the number of nodes in the left subtree is always a power of two. In this case, the indices of the left and right children of a node with index `i` are `2 * i` and `2 * i + 1` (assuming the root node has index 1). This can help with cache coherence and can improve the efficiency of tree traversal (e.g. during queries).
 
 Other trees useful for polygon meshing may be added in the future, such as octrees, bounding volume hierarchies, or alternating digital trees.
 
-#### **why another kdtree library?**
+#### **Why another kdtree library?**
 
 I use kdtrees for computing Voronoi diagrams via the radius of security theorem, which requires the nearest neighbors to each Voronoi site. My goal was to reduce the memory footprint and try to improve the efficiency of the tree construction and query process. In developing the left-balanced kdtree implementation, my hope was that the querying procedures could eventually be ported to GPUs so that the nearest neighbor query and Voronoi cell construction could be done simultaneously in a kernel. I had tried writing the balanced-tree query process in CUDA but didn't see much of an improvement, likely because of memory coalescence and thread divergence. I haven't tried the query process yet with left-balanced trees (which is stackless, following Ingo Wald's recent work) on the GPU, but it might be more efficient. Please feel free to open a PR which implements this!
 
-### **using the `maple` API**
+### **Using the `trees` API**
 
-All `mapletrees` functionality is enclosed within the `maple` namespace. `mapletrees` expects the input point coordinates to be stored in a single flattened array where the dimension of the points is the stride taken along the array when traversing from one point to the next. For example, `points[3 * k]` is the x-coordinate of the `k`-th point, while `points[3 * k + 1]` and `points[3 * k + 2]` are the y- and z-coordinates, respectively.
+All functionality is enclosed within the `trees` namespace. `trees` expects the input point coordinates to be stored in a single flattened array where the dimension of the points is the stride taken along the array when traversing from one point to the next. For example, `points[3 * k]` is the x-coordinate of the `k`-th point, while `points[3 * k + 1]` and `points[3 * k + 2]` are the y- and z-coordinates, respectively.
 
 With this point representation, the balanced tree can be constructed as:
 
@@ -22,20 +22,20 @@ const size_t n_points = 1e7; // 10M points
 using coord_t = double; // the type of the point coordinates (either float or double)
 using index_t = uint32_t; // how integers should be represented
 std::vector<coord_t> points(n_points * 3); // ... and then fill point coordinates
-maple::KdTreeOptions options; // it's optional to pass this to the constructor
-maple::KdTree<dim, coord_t, index_t> tree(points.data(), n_points, options);
+trees::KdTreeOptions options; // it's optional to pass this to the constructor
+trees::KdTree<dim, coord_t, index_t> tree(points.data(), n_points, options);
 ```
 
 Alternatively, for a left-balanced tree, the last line would be:
 
 ```c++
 static constexpr bool with_leaves = true;
-maple::KdTree_LeftBalanced<dim, coord_t, index_t, with_leaves> tree(points.data(), n_points, options);
+trees::KdTree_LeftBalanced<dim, coord_t, index_t, with_leaves> tree(points.data(), n_points, options);
 ```
 
 Note that for a left-balanced tree, there is an additional template parameter `with_leaves` which will build the tree with a bucket of points in the leaves if true. This is a template parameter because the internal structure used to represent nodes will require less memory if there are no leaf buckets, and construction will be faster. However, the query time will be slower if there are no buckets in the leaves. The number of points in a leaf bucket can be controlled by the `KdTreeOptions` structure (also applicable to regular balanced trees) via the `leaf_size` member.
 
-#### nearest neighbor queries
+#### Nearest neighbor queries
 
 Once the `tree` has been constructed, the k-nearest neighbors of an input query point `x` can be computed as in the following:
 
@@ -43,7 +43,7 @@ Once the `tree` has been constructed, the k-nearest neighbors of an input query 
 static constexpr int k = 10; // number of nearest neighbors requested
 std::array<index_t, k> neighbors; // set up neighbors and distances buffers
 std::array<coord_t, k> distances;
-using Search_t = maple::NearestNeighborSearch<index_t, coord_t>;
+using Search_t = trees::NearestNeighborSearch<index_t, coord_t>;
 Search_t search(k, neighbors.data(), distances.data());
 tree.knearest(x, search);
 ```
@@ -52,13 +52,13 @@ The indices of the neighbors (and corresponding distances to `x`) will be filled
 
 There is some initial support for a radius search (i.e. all points within a radius around an input point) but this is not well tested or optimized yet, so I don't recommend using it (another good idea for a PR!).
 
-### **performance**
+### **Performance**
 
-`mapletrees` was primarily compared with the `nanoflann` library since that is what I mostly used in the past. Overall, construction is faster than `nanoflann`, but querying can be slower. However, the crossover of when this happens usually occurs for problems that I don't generally work on, specifically when doing an all-nearest neighbor query for k > 100. Hopefully, the data included in the **Issues** tab will help to know which kdtree library to select for your application. The latest results are described [here](https://github.com/middpolymer/mapletrees/issues/1).
+The `trees` library was primarily compared with the `nanoflann` library since that is what I mostly used in the past. Overall, construction is faster than `nanoflann`, but querying can be slower. However, the crossover of when this happens usually occurs for problems that I don't generally work on, specifically when doing an all-nearest neighbor query for k > 100. Hopefully, the data included in the **Issues** tab will help to know which kdtree library to select for your application. The latest results are described [here](https://github.com/middpolymer/trees/issues/1).
 
 Both balanced and left-balanced (with leaf buckets) trees require `3 x sizeof(index_t)` bytes per point. The left-balanced tree without leaf buckets requires `sizeof(index_t)` bytes per point. `nanoflann` seems to require between 3-4 `x sizeof(index_t)` per point.
 
-### **LICENSE**
+### **License**
 
 `mapletrees` is distributed under the Apache-2.0 License.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Both balanced and left-balanced (with leaf buckets) trees require `3 x sizeof(in
 
 ### **License**
 
-`mapletrees` is distributed under the Apache-2.0 License.
+The `trees` library is distributed under the Apache-2.0 License.
 
 Copyright 2023 Philip Claude Caplan
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ There is some initial support for a radius search (i.e. all points within a radi
 
 The `trees` library was primarily compared with the `nanoflann` library since that is what I mostly used in the past. Overall, construction is faster than `nanoflann`, but querying can be slower. However, the crossover of when this happens usually occurs for problems that I don't generally work on, specifically when doing an all-nearest neighbor query for k > 100. Hopefully, the data included in the **Issues** tab will help to know which kdtree library to select for your application. The latest results are described [here](https://github.com/middpolymer/trees/issues/1).
 
+A smaller set of tests are run using GitHub Actions during each pull request. The latest results for these tests are updated here:
+
+<img src="https://middpolymer.github.io/trees/build-k10.png
+" width=250/><img src="https://middpolymer.github.io/trees/query-k10.png
+" width=250/><img src="https://middpolymer.github.io/trees/total-k10.png
+" width=250/>
+
 Both balanced and left-balanced (with leaf buckets) trees require `3 x sizeof(index_t)` bytes per point. The left-balanced tree without leaf buckets requires `sizeof(index_t)` bytes per point. `nanoflann` seems to require between 3-4 `x sizeof(index_t)` per point.
 
 ### **License**

--- a/kdtree.h
+++ b/kdtree.h
@@ -1,5 +1,5 @@
 //
-// mapletrees
+// trees
 // Copyright 2023 Philip Claude Caplan
 //
 // Licensed under the Apache License,
@@ -40,7 +40,7 @@
 #define kdtree_assert(X) assert(X)
 #endif
 
-#define MAPLE_ASSERT(x)                                                  \
+#define KDTREE_ASSERT(x)                                                 \
   {                                                                      \
     if (!(x)) {                                                          \
       std::cerr << "assertion failed: " << #x << " (" << __FILE__ << ":" \
@@ -49,7 +49,7 @@
     }                                                                    \
   }
 
-namespace maple {
+namespace trees {
 
 enum class NearestNeighborApproach : uint8_t { kRecursive = 0, kIterative = 1 };
 struct KdTreeOptions {
@@ -79,7 +79,7 @@ template <typename index_t, typename coord_t> struct NearestNeighborSearch {
 
   NearestNeighborSearch(int n, index_t* n_buffer, coord_t* d_buffer)
       : k(n), neighbors(n_buffer), distances(d_buffer) {
-    MAPLE_ASSERT(k > 1);
+    KDTREE_ASSERT(k > 1);
     reset();
   }
 
@@ -368,7 +368,7 @@ class KdTree : public KdTreeNd<coord_t, index_t> {
 
   void knearest(const coord_t* x,
                 NearestNeighborSearch<index_t, coord_t>& search) const {
-    MAPLE_ASSERT(search.approach == NearestNeighborApproach::kRecursive);
+    KDTREE_ASSERT(search.approach == NearestNeighborApproach::kRecursive);
     search_recursive(x, search);
     search.finalize();
   }
@@ -856,12 +856,12 @@ class KdTree_LeftBalanced : public KdTreeNd<coord_t, index_t> {
   std::mutex lock_;
 };
 
-}  // namespace maple
+}  // namespace trees
 
 #if HAVE_NANOFLANN
 template <int8_t dim, typename coord_t = double, typename index_t = uint32_t,
           bool with_leaves = true>
-class KdTree_nanoflann : public maple::KdTreeNd<coord_t, index_t> {
+class KdTree_nanoflann : public trees::KdTreeNd<coord_t, index_t> {
  private:
   class PointCloud {
    public:
@@ -882,7 +882,7 @@ class KdTree_nanoflann : public maple::KdTreeNd<coord_t, index_t> {
 
  public:
   KdTree_nanoflann(const coord_t* x, size_t n,
-                   maple::KdTreeOptions options = maple::KdTreeOptions())
+                   trees::KdTreeOptions options = trees::KdTreeOptions())
       : cloud_(x, n) {
     tree_ = std::make_unique<nanoflann::KDTreeSingleIndexAdaptor<
         nanoflann::L2_Adaptor<coord_t, PointCloud>, PointCloud, dim> >(
@@ -893,7 +893,7 @@ class KdTree_nanoflann : public maple::KdTreeNd<coord_t, index_t> {
   }
 
   void knearest(const coord_t* x,
-                maple::NearestNeighborSearch<index_t, coord_t>& search) const {
+                trees::NearestNeighborSearch<index_t, coord_t>& search) const {
     (void)tree_->knnSearch(x, search.k, search.neighbors, search.distances);
   }
 

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -54,14 +54,16 @@ h_lf = plt.loglog(sizes, build["left-balanced-leaf-full"], 'o-')
 h_le = plt.loglog(sizes, build["left-balanced-leaf-empty"], 'o-')
 plt.xlabel('# points', fontsize=12)
 plt.title('build time (s)', fontsize=12)
-plt.annotate('nanoflann', weight='bold', xy=(
-    10 ** 5, 0.04), color=h_n[0].get_color())
-plt.annotate('balanced', weight='bold',
-             xy=(10 ** 7, 0.2), color=h_b[0].get_color())
-plt.annotate('left-balanced\n(max 12 points / leaf)', weight='bold', xy=(10 ** 7.5, 2.5), xytext=(10 ** 6, 4),
-             arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_lf[0].get_color(), headwidth=8), color=h_lf[0].get_color())
-plt.annotate('left-balanced\n(1 point / leaf)', weight='bold', xy=(10 ** 6.025, 0.03), xytext=(10 ** 6.25, 0.004),
-             arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_le[0].get_color(), headwidth=8), color=h_le[0].get_color())
+plt.legend(handles=[h_b[0], h_lf[0], h_le[0], h_n[0]], labels=[
+           'balanced', 'left-bal. (12 pts/leaf)', 'left-bal. (1 pt/leaf)' 'nanoflann'])
+# plt.annotate('nanoflann', weight='bold', xy=(
+#     10 ** 5, 0.04), color=h_n[0].get_color())
+# plt.annotate('balanced', weight='bold',
+#              xy=(10 ** 7, 0.2), color=h_b[0].get_color())
+# plt.annotate('left-balanced\n(max 12 points / leaf)', weight='bold', xy=(10 ** 7.5, 2.5), xytext=(10 ** 6, 4),
+#              arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_lf[0].get_color(), headwidth=8), color=h_lf[0].get_color())
+# plt.annotate('left-balanced\n(1 point / leaf)', weight='bold', xy=(10 ** 6.025, 0.03), xytext=(10 ** 6.25, 0.004),
+#              arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_le[0].get_color(), headwidth=8), color=h_le[0].get_color())
 plt.savefig(f"{dst}/build-k{k}.{ext}", dpi=resolution)
 
 plt.figure()

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -55,7 +55,7 @@ h_le = plt.loglog(sizes, build["left-balanced-leaf-empty"], 'o-')
 plt.xlabel('# points', fontsize=12)
 plt.title('build time (s)', fontsize=12)
 plt.legend(handles=[h_b[0], h_lf[0], h_le[0], h_n[0]], labels=[
-           'balanced', 'left-bal. (12 pts/leaf)', 'left-bal. (1 pt/leaf)' 'nanoflann'])
+           'balanced', 'left-balanced (12 pts/leaf)', 'left-balanced (1 pt/leaf)', 'nanoflann'])
 # plt.annotate('nanoflann', weight='bold', xy=(
 #     10 ** 5, 0.04), color=h_n[0].get_color())
 # plt.annotate('balanced', weight='bold',

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -84,4 +84,4 @@ plt.legend(handles=[h_b[0], h_l[0], h_n[0]], labels=[
            'balanced', 'left-balanced', 'nanoflann'])
 plt.savefig(f"{dst}/total-k{k}.{ext}", dpi=resolution)
 
-plt.show()
+# plt.show()

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -10,7 +10,7 @@ dst = "figures"
 method_name = {0: "balanced", 1: "left-balanced-leaf-full",
                2: "left-balanced-leaf-empty", 3: "nanoflann"}
 
-k = 100
+k = 10
 power = [5, 6, 7, 8]
 sizes = [10 ** p for p in power]
 build = {}

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -1,4 +1,4 @@
-from matplotlib import pyplot as plt 
+from matplotlib import pyplot as plt
 import json
 
 plt.rcParams["font.family"] = "Futura"
@@ -7,9 +7,10 @@ ext = 'png'
 resolution = 144
 dst = "figures"
 
-method_name = {0: "balanced", 1: "left-balanced-leaf-full", 2: "left-balanced-leaf-empty", 3: "nanoflann"}
+method_name = {0: "balanced", 1: "left-balanced-leaf-full",
+               2: "left-balanced-leaf-empty", 3: "nanoflann"}
 
-k = 50
+k = 100
 power = [5, 6, 7, 8]
 sizes = [10 ** p for p in power]
 build = {}
@@ -30,19 +31,6 @@ for m in [0, 1, 2, 3]:
             t_b.append(data["t_build"])
             t_q.append(data["t_knn"])
             mem.append(data["memory"])
-            '''
-            data = f.read()
-            s = data.split(',')
-            for i in range(len(s)):
-                if 'method' in s[i]:
-                    t = s[i].split(':')
-                    u = ("\"" + t[1] + "\"").replace(' ','')
-                    data = data.replace(t[1], u)
-                    print(data)
-                    with open("results/" + filename, "w") as g:
-                        g.write(data)
-                        break
-            '''
 
     method = method_name[m]
     build[method] = t_b
@@ -56,7 +44,8 @@ print(memory)
 total = {}
 for method in build:
     assert method in query
-    total[method] = [build[method][i] + query[method][i] for i in range(len(build[method]))]
+    total[method] = [build[method][i] + query[method][i]
+                     for i in range(len(build[method]))]
 
 plt.figure()
 h_b = plt.loglog(sizes, build["balanced"], 'o-')
@@ -65,10 +54,14 @@ h_lf = plt.loglog(sizes, build["left-balanced-leaf-full"], 'o-')
 h_le = plt.loglog(sizes, build["left-balanced-leaf-empty"], 'o-')
 plt.xlabel('# points', fontsize=12)
 plt.title('build time (s)', fontsize=12)
-plt.annotate('nanoflann', weight='bold', xy = (10 ** 5, 0.04), color=h_n[0].get_color())
-plt.annotate('maple-balanced', weight='bold', xy = (10 ** 7, 0.2), color = h_b[0].get_color())
-plt.annotate('maple-left-balanced\n(max 12 points / leaf)', weight='bold', xy = (10 ** 7.5, 2.5), xytext = (10 ** 6, 4), arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_lf[0].get_color(), headwidth=8), color = h_lf[0].get_color())
-plt.annotate('maple-left-balanced\n(1 point / leaf)', weight='bold', xy = (10 ** 6.025, 0.03), xytext = (10 ** 6.25, 0.004), arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor = h_le[0].get_color(), headwidth=8), color = h_le[0].get_color())
+plt.annotate('nanoflann', weight='bold', xy=(
+    10 ** 5, 0.04), color=h_n[0].get_color())
+plt.annotate('balanced', weight='bold',
+             xy=(10 ** 7, 0.2), color=h_b[0].get_color())
+plt.annotate('left-balanced\n(max 12 points / leaf)', weight='bold', xy=(10 ** 7.5, 2.5), xytext=(10 ** 6, 4),
+             arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_lf[0].get_color(), headwidth=8), color=h_lf[0].get_color())
+plt.annotate('left-balanced\n(1 point / leaf)', weight='bold', xy=(10 ** 6.025, 0.03), xytext=(10 ** 6.25, 0.004),
+             arrowprops=dict(shrink=0.01, width=2, edgecolor='black', facecolor=h_le[0].get_color(), headwidth=8), color=h_le[0].get_color())
 plt.savefig(f"{dst}/build-k{k}.{ext}", dpi=resolution)
 
 plt.figure()
@@ -77,21 +70,8 @@ h_n = plt.loglog(sizes, query["nanoflann"], 'o--')
 h_l = plt.loglog(sizes, query["left-balanced-leaf-full"], '^-')
 plt.xlabel('# points', fontsize=12)
 plt.title(f"k = {k}, query time (s)", fontsize=12)
-plt.legend(handles=[h_b[0], h_l[0], h_n[0]], labels=['maple-balanced', 'maple-left-balanced', 'nanoflann'])
-'''
-p = (10 ** 5, 0.1)
-if k == 50:
-    p = (10 ** 5, 0.2)
-elif k == 100:
-    p = (10 ** 5, 0.4)
-plt.annotate('nanoflann', weight='bold', xy = p, color=h_n[0].get_color())
-p = (10 ** 7, 0.8)
-if k == 50:
-    p = (10 ** 7, 2)
-elif k == 100:
-    p = (10 ** 7, 6)
-plt.annotate('maple-balanced', weight='bold', xy = p, color = h_b[0].get_color())
-'''
+plt.legend(handles=[h_b[0], h_l[0], h_n[0]], labels=[
+           'balanced', 'left-balanced', 'nanoflann'])
 plt.savefig(f"{dst}/query-k{k}.{ext}", dpi=resolution)
 
 plt.figure()
@@ -100,21 +80,8 @@ h_n = plt.loglog(sizes, total["nanoflann"], 'o--')
 h_l = plt.loglog(sizes, total["left-balanced-leaf-full"], '^-')
 plt.xlabel('# points', fontsize=12)
 plt.title(f"k = {k}, build + query time (s)", fontsize=12)
-plt.legend(handles=[h_b[0], h_l[0], h_n[0]], labels=['maple-balanced', 'maple-left-balanced', 'nanoflann'])
-'''
-p = (10 ** 5, 0.1)
-if k == 50:
-    p = (10 ** 5, 0.2)
-elif k == 100:
-    p = (10 ** 5, 0.4)
-plt.annotate('nanoflann', weight='bold', xy = p, color=h_n[0].get_color())
-p = (10 ** 7, 0.8)
-if k == 50:
-    p = (10 ** 7, 2)
-elif k == 100:
-    p = (10 ** 7, 6)
-plt.annotate('maple-balanced', weight='bold', xy = p, color = h_b[0].get_color())
-'''
+plt.legend(handles=[h_b[0], h_l[0], h_n[0]], labels=[
+           'balanced', 'left-balanced', 'nanoflann'])
 plt.savefig(f"{dst}/total-k{k}.{ext}", dpi=resolution)
 
 plt.show()

--- a/test/analyze.py
+++ b/test/analyze.py
@@ -11,7 +11,7 @@ method_name = {0: "balanced", 1: "left-balanced-leaf-full",
                2: "left-balanced-leaf-empty", 3: "nanoflann"}
 
 k = 10
-power = [5, 6, 7, 8]
+power = [5, 6, 7]
 sizes = [10 ** p for p in power]
 build = {}
 query = {}

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -1,16 +1,46 @@
 import os
+import argparse
+
 
 def run(method, n_values, k, n_leaf, approach, n_test):
-	if (method == 2):
-		n_leaf = 1
-	for n in n_values:
-		cmd = f"./test_kdtree {method} {n} {k} {n_leaf} {approach} {n_test}"
-		os.system(cmd)
+    if (method == 2):
+        n_leaf = 1
+    for n in n_values:
+        cmd = f"./test_kdtree {method} {n} {k} {n_leaf} {approach} {n_test}"
+        os.system(cmd)
 
-n = [10000, 100000, 1000000, 10000000, 100000000]
-k = 100
-nl = 12
-nt = 10
-approach = 0
-for method in [3, 0, 1, 2]:
-	run(method, n, k, nl, approach, nt)
+
+def full_benchmark():
+    return
+    n = [10000, 100000, 1000000, 10000000, 100000000]
+    k = 100
+    nl = 12
+    nt = 10
+    approach = 0
+    for method in [3, 0, 1, 2]:
+        run(method, n, k, nl, approach, nt)
+
+
+def lite_benchmark():
+    n = [10000, 100000, 1000000, 10000000, 50000000]
+    k = 10
+    nl = 12
+    nt = 10
+    approach = 0
+    for method in [0, 1, 2, 3]:
+        run(method, n, k, nl, approach, nt)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Process some integers')
+    parser.add_argument('--test', default="lite",
+                        help='which tests to run, either full or lite')
+    args = parser.parse_args()
+    print(args.test)
+    if args.test == 'lite':
+        lite_benchmark()
+    else:
+        full_benchmark()
+
+
+main()

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -22,10 +22,10 @@ def full_benchmark():
 
 
 def lite_benchmark():
-    n = [10000, 100000, 1000000, 10000000, 25000000]
+    n = [10000, 100000, 1000000, 10000000]
     k = 10
     nl = 12
-    nt = 5
+    nt = 3
     approach = 0
     for method in [0, 1, 2, 3]:
         run(method, n, k, nl, approach, nt)

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -22,10 +22,10 @@ def full_benchmark():
 
 
 def lite_benchmark():
-    n = [10000, 100000, 1000000, 10000000, 50000000]
+    n = [10000, 100000, 1000000, 10000000, 25000000]
     k = 10
     nl = 12
-    nt = 10
+    nt = 5
     approach = 0
     for method in [0, 1, 2, 3]:
         run(method, n, k, nl, approach, nt)

--- a/test/test_kdtree.cpp
+++ b/test/test_kdtree.cpp
@@ -6,12 +6,10 @@
 
 struct json {
   json() { str = "{\n"; }
-  template <typename T>
-  std::string convert(const T& v) {
+  template <typename T> std::string convert(const T& v) {
     return std::to_string(v);
   }
-  template <typename T>
-  void add(const std::string& key, const T& v) {
+  template <typename T> void add(const std::string& key, const T& v) {
     if (n_keys > 0) str += ",\n";
     str += "\t\"" + key + "\": " + convert(v);
     n_keys++;
@@ -22,10 +20,7 @@ struct json {
   std::string str;
 };
 
-template <>
-std::string json::convert(const std::string& v) {
-  return v;
-}
+template <> std::string json::convert(const std::string& v) { return v; }
 
 using index_t = uint32_t;
 using coord_t = double;
@@ -69,16 +64,16 @@ int main(int argc, char** argv) {
     std::vector<index_t> order(n);
     timer.stop();
     std::cout << "alloc time = " << timer.seconds() << " s. " << std::endl;
-    for (auto& x : coord)
-      x = coord_t(rand()) / coord_t(RAND_MAX);
+    for (auto& x : coord) x = coord_t(rand()) / coord_t(RAND_MAX);
 
-    timer.start();
-    sort_points_on_zcurve(coord.data(), n, dim, order);
-    timer.stop();
-    std::cout << "zcurve time = " << timer.seconds() << " s. " << std::endl;
-    t_zcurve += timer.seconds() / n_test;
+    if (use_zcurve) {
+      timer.start();
+      sort_points_on_zcurve(coord.data(), n, dim, order);
+      timer.stop();
+      std::cout << "zcurve time = " << timer.seconds() << " s. " << std::endl;
+      t_zcurve += timer.seconds() / n_test;
+    }
 
-    coord_t x[dim];
     std::parafor_i(0, n, [&](int thread_id, index_t i) {
       for (int d = 0; d < dim; d++)
         points[dim * i + d] = coord[dim * order[i] + d];
@@ -125,7 +120,7 @@ int main(int argc, char** argv) {
     std::vector<int> n_k(n_thread, 0), n_p(n_thread);
     std::parafor_i(
         0, n,
-        [&](int tid, int i) {
+        [&](int tid, size_t i) {
           int capacity = n_neighbors;
           index_t* neighbors = (index_t*)alloca(capacity * sizeof(index_t));
           coord_t* distances = (coord_t*)alloca(capacity * sizeof(coord_t));

--- a/test/test_kdtree.cpp
+++ b/test/test_kdtree.cpp
@@ -9,6 +9,7 @@ struct json {
   template <typename T> std::string convert(const T& v) {
     return std::to_string(v);
   }
+
   template <typename T> void add(const std::string& key, const T& v) {
     if (n_keys > 0) str += ",\n";
     str += "\t\"" + key + "\": " + convert(v);
@@ -20,7 +21,9 @@ struct json {
   std::string str;
 };
 
-template <> std::string json::convert(const std::string& v) { return v; }
+template <> std::string json::convert(const std::string& v) {
+  return "\"" + v + "\"";
+}
 
 using index_t = uint32_t;
 using coord_t = double;

--- a/test/test_kdtree.cpp
+++ b/test/test_kdtree.cpp
@@ -33,8 +33,8 @@ int main(int argc, char** argv) {
   const int dim = 3;
   Timer timer;
   bool use_zcurve = true;
-  maple::NearestNeighborApproach approach =
-      maple::NearestNeighborApproach::kRecursive;
+  trees::NearestNeighborApproach approach =
+      trees::NearestNeighborApproach::kRecursive;
   int n_neighbors = 10;
   int leaf_size = 12;
   int n_test = 1;
@@ -46,8 +46,8 @@ int main(int argc, char** argv) {
   if (argc > 4) leaf_size = std::atoi(argv[4]);
   if (argc > 5)
     approach = std::atoi(argv[5]) > 0
-                   ? maple::NearestNeighborApproach::kIterative
-                   : maple::NearestNeighborApproach::kRecursive;
+                   ? trees::NearestNeighborApproach::kIterative
+                   : trees::NearestNeighborApproach::kRecursive;
   if (argc > 6) n_test = std::atoi(argv[6]);
 
   double t_zcurve = 0;
@@ -87,21 +87,21 @@ int main(int argc, char** argv) {
 
     std::cout << "building kdtree for " << n / 1e6 << "M points" << std::endl;
     timer.start();
-    maple::KdTreeOptions options;
+    trees::KdTreeOptions options;
     options.leaf_size = leaf_size;
     options.parallel = true;
 
-    std::shared_ptr<maple::KdTreeNd<coord_t, index_t>> tree{nullptr};
+    std::shared_ptr<trees::KdTreeNd<coord_t, index_t>> tree{nullptr};
     if (method == 0)
-      tree = std::make_shared<maple::KdTree<dim, coord_t, index_t>>(
+      tree = std::make_shared<trees::KdTree<dim, coord_t, index_t>>(
           points.data(), n, options);
     else if (method == 1)
       tree = std::make_shared<
-          maple::KdTree_LeftBalanced<dim, coord_t, index_t, true>>(
+          trees::KdTree_LeftBalanced<dim, coord_t, index_t, true>>(
           points.data(), n, options);
     else if (method == 2) {
       tree = std::make_shared<
-          maple::KdTree_LeftBalanced<dim, coord_t, index_t, false>>(
+          trees::KdTree_LeftBalanced<dim, coord_t, index_t, false>>(
           points.data(), n, options);
     } else if (method == 3) {
       tree = std::make_shared<KdTree_nanoflann<dim, coord_t, index_t>>(
@@ -127,9 +127,9 @@ int main(int argc, char** argv) {
           int capacity = n_neighbors;
           index_t* neighbors = (index_t*)alloca(capacity * sizeof(index_t));
           coord_t* distances = (coord_t*)alloca(capacity * sizeof(coord_t));
-          using Search_t = maple::NearestNeighborSearch<index_t, coord_t>;
+          using Search_t = trees::NearestNeighborSearch<index_t, coord_t>;
           if (method == 3)
-            approach = maple::NearestNeighborApproach::kRecursive;
+            approach = trees::NearestNeighborApproach::kRecursive;
           Search_t search(n_neighbors, neighbors, distances);
           search.approach = approach;
 
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
   stats.add("t_build", t_build);
   stats.add("k", n_neighbors);
   stats.add("approach",
-            approach == maple::NearestNeighborApproach::kRecursive ? 0 : 1);
+            approach == trees::NearestNeighborApproach::kRecursive ? 0 : 1);
   stats.add("t_knn", t_knn);
   stats.add("leaf_size", used_leaf_size);
   stats.add("memory", memory);

--- a/util.h
+++ b/util.h
@@ -1,5 +1,5 @@
 //
-// mapletrees
+// trees
 // Copyright 2023 Philip Claude Caplan
 //
 // Licensed under the Apache License,
@@ -40,42 +40,34 @@ constexpr auto encoder64_2d = MortonNDLutEncoder<2, 32, 10>();
 constexpr auto encoder64_3d = MortonNDLutEncoder<3, 21, 10>();
 constexpr auto encoder64_4d = MortonNDLutEncoder<4, 16, 10>();
 
-template <int dim>
-struct Resolution;
+template <int dim> struct Resolution;
 
-template <>
-struct Resolution<2> {
+template <> struct Resolution<2> {
   // 32 bits for each coordinate
   static constexpr double value = 4294967296.0;
 };
 
-template <>
-struct Resolution<3> {
+template <> struct Resolution<3> {
   // 21 bits for each coordinate
   static constexpr double value = 2091752.0;
 };
 
-template <>
-struct Resolution<4> {
+template <> struct Resolution<4> {
   // 16 bits for each coordinate
   static constexpr double value = 65536.0;
 };
 
-template <int dim>
-morton_t encode(const std::array<uint64_t, dim>& x);
+template <int dim> morton_t encode(const std::array<uint64_t, dim>& x);
 
-template <>
-morton_t encode<2>(const std::array<uint64_t, 2>& x) {
+template <> morton_t encode<2>(const std::array<uint64_t, 2>& x) {
   return encoder64_2d.Encode(x[0], x[1]);
 }
 
-template <>
-morton_t encode<3>(const std::array<uint64_t, 3>& x) {
+template <> morton_t encode<3>(const std::array<uint64_t, 3>& x) {
   return encoder64_3d.Encode(x[0], x[1], x[2]);
 }
 
-template <>
-morton_t encode<4>(const std::array<uint64_t, 4>& x) {
+template <> morton_t encode<4>(const std::array<uint64_t, 4>& x) {
   return encoder64_4d.Encode(x[0], x[1], x[2], x[3]);
 }
 
@@ -104,11 +96,8 @@ morton_t encode_morton(const T* values, int dim, const T* xmin, const T* xmax) {
 }
 
 template <typename coord_t>
-void get_bounding_box(const coord_t* points,
-                      int64_t n_points,
-                      int8_t dim,
-                      coord_t* xmin,
-                      coord_t* xmax) {
+void get_bounding_box(const coord_t* points, int64_t n_points, int8_t dim,
+                      coord_t* xmin, coord_t* xmax) {
   std::fill(xmin, xmin + dim, std::numeric_limits<coord_t>::max());
   std::fill(xmax, xmax + dim, std::numeric_limits<coord_t>::min());
   for (int64_t i = 0; i < n_points; i++) {
@@ -121,9 +110,7 @@ void get_bounding_box(const coord_t* points,
 }
 
 template <typename coord_t, typename index_t>
-void sort_points_on_zcurve(const coord_t* points,
-                           uint64_t n_points,
-                           int8_t dim,
+void sort_points_on_zcurve(const coord_t* points, uint64_t n_points, int8_t dim,
                            std::vector<index_t>& order) {
   std::vector<coord_t> xmin(dim), xmax(dim);
   get_bounding_box(points, n_points, dim, xmin.data(), xmax.data());
@@ -134,6 +121,5 @@ void sort_points_on_zcurve(const coord_t* points,
   std::parasort(z.begin(), z.end(), [](const auto& p, const auto& q) {
     return p.second < q.second;
   });
-  for (uint64_t k = 0; k < n_points; k++)
-    order[k] = z[k].first;
+  for (uint64_t k = 0; k < n_points; k++) order[k] = z[k].first;
 }


### PR DESCRIPTION
### Summary

This PR fixes some compiler warnings, renames this project to `trees` and adds a workflow to build, test and generate results from a subset of the full benchmarks (up to 10M with k = 10) during every PR.

### Testing

Full benchmarks (up to 100M with k = 100) were run locally:

<img width="300" alt="build-k100" src="https://github.com/middpolymer/trees/assets/15183590/417fa7c9-fbd9-471d-8f5d-f1b95342c38d">
<img width="300" alt="query-k100" src="https://github.com/middpolymer/trees/assets/15183590/7c9d10a6-95f2-4d5e-ae67-930cccb516c4">
<img width="300" alt="total-k100" src="https://github.com/middpolymer/trees/assets/15183590/7e2b0f0a-a180-45a2-80aa-af9a4eb05c7c">

